### PR TITLE
Improvements to `DesiredComposedResources` and `ObservedComposedResources`

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -67,10 +67,10 @@ func GetDesiredCompositeResource(req *v1beta1.RunFunctionRequest) (*resource.Com
 }
 
 // GetDesiredComposedResources from the supplied request.
-func GetDesiredComposedResources(req *v1beta1.RunFunctionRequest) (map[resource.Name]resource.DesiredComposed, error) {
-	dcds := map[resource.Name]resource.DesiredComposed{}
+func GetDesiredComposedResources(req *v1beta1.RunFunctionRequest) (map[resource.Name]*resource.DesiredComposed, error) {
+	dcds := map[resource.Name]*resource.DesiredComposed{}
 	for name, r := range req.GetDesired().GetResources() {
-		dcd := resource.DesiredComposed{Resource: composed.New()}
+		dcd := &resource.DesiredComposed{Resource: composed.New()}
 		if err := resource.AsObject(r.GetResource(), dcd.Resource); err != nil {
 			return nil, err
 		}

--- a/request/request.go
+++ b/request/request.go
@@ -44,8 +44,8 @@ func GetObservedCompositeResource(req *v1beta1.RunFunctionRequest) (*resource.Co
 }
 
 // GetObservedComposedResources from the supplied request.
-func GetObservedComposedResources(req *v1beta1.RunFunctionRequest) (resource.ObservedComposedResources, error) {
-	ocds := resource.ObservedComposedResources{}
+func GetObservedComposedResources(req *v1beta1.RunFunctionRequest) (map[resource.Name]resource.ObservedComposed, error) {
+	ocds := map[resource.Name]resource.ObservedComposed{}
 	for name, r := range req.GetObserved().GetResources() {
 		ocd := resource.ObservedComposed{Resource: composed.New(), ConnectionDetails: r.GetConnectionDetails()}
 		if err := resource.AsObject(r.GetResource(), ocd.Resource); err != nil {
@@ -67,14 +67,14 @@ func GetDesiredCompositeResource(req *v1beta1.RunFunctionRequest) (*resource.Com
 }
 
 // GetDesiredComposedResources from the supplied request.
-func GetDesiredComposedResources(req *v1beta1.RunFunctionRequest) (resource.DesiredComposedResources, error) {
-	ocds := resource.DesiredComposedResources{}
+func GetDesiredComposedResources(req *v1beta1.RunFunctionRequest) (map[resource.Name]resource.DesiredComposed, error) {
+	dcds := map[resource.Name]resource.DesiredComposed{}
 	for name, r := range req.GetDesired().GetResources() {
-		ocd := resource.DesiredComposed{Resource: composed.New()}
-		if err := resource.AsObject(r.GetResource(), ocd.Resource); err != nil {
+		dcd := resource.DesiredComposed{Resource: composed.New()}
+		if err := resource.AsObject(r.GetResource(), dcd.Resource); err != nil {
 			return nil, err
 		}
-		ocds[resource.Name(name)] = ocd
+		dcds[resource.Name(name)] = dcd
 	}
-	return ocds, nil
+	return dcds, nil
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -68,17 +68,11 @@ func NewDesiredComposedResource() DesiredComposed {
 	return DesiredComposed{Resource: composed.New()}
 }
 
-// DesiredComposedResources  indexed by resource name.
-type DesiredComposedResources map[Name]DesiredComposed
-
 // ObservedComposed reflects the observed state of a composed resource.
 type ObservedComposed struct {
 	Resource          *composed.Unstructured
 	ConnectionDetails ConnectionDetails
 }
-
-// ObservedComposedResources indexed by resource name.
-type ObservedComposedResources map[Name]ObservedComposed
 
 // AsObject gets the supplied Kubernetes object from the supplied struct.
 func AsObject(s *structpb.Struct, o runtime.Object) error {

--- a/response/response.go
+++ b/response/response.go
@@ -61,7 +61,7 @@ func SetDesiredCompositeResource(rsp *v1beta1.RunFunctionResponse, xr *resource.
 // supplied response. The caller must be sure to avoid overwriting the desired
 // state that may have been accumulated by previous Functions in the pipeline,
 // unless they intend to.
-func SetDesiredComposedResources(rsp *v1beta1.RunFunctionResponse, dcds map[resource.Name]resource.DesiredComposed) error {
+func SetDesiredComposedResources(rsp *v1beta1.RunFunctionResponse, dcds map[resource.Name]*resource.DesiredComposed) error {
 	if rsp.Desired == nil {
 		rsp.Desired = &v1beta1.State{}
 	}

--- a/response/response.go
+++ b/response/response.go
@@ -61,7 +61,7 @@ func SetDesiredCompositeResource(rsp *v1beta1.RunFunctionResponse, xr *resource.
 // supplied response. The caller must be sure to avoid overwriting the desired
 // state that may have been accumulated by previous Functions in the pipeline,
 // unless they intend to.
-func SetDesiredComposedResources(rsp *v1beta1.RunFunctionResponse, dcds resource.DesiredComposedResources) error {
+func SetDesiredComposedResources(rsp *v1beta1.RunFunctionResponse, dcds map[resource.Name]resource.DesiredComposed) error {
 	if rsp.Desired == nil {
 		rsp.Desired = &v1beta1.State{}
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This makes it possible to mutate struct values while iterating over the map of composed resources. I found myself naturally wanting to do this while writing a Function. e.g.:

```go
desired, _ = request.GetDesiredComposedResources(req)

for _, dr := range desired {
	dr.Ready = resource.ReadyTrue
}

_ = response.SetDesiredComposedResources(desired)
```

I haven't made the same change for observed resources, since they're supposed to be read-only to a Function.

This PR also removes the `DesiredComposedResources` and `ObservedComposedResources` types. I found they were just obfuscating what the types actually were when I tried to use them.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
