### PR TITLE
Make Ready enum a string

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -54,13 +54,13 @@ type DesiredComposed struct {
 }
 
 // Ready indicates whether a composed resource should be considered ready.
-type Ready int
+type Ready string
 
 // Composed resource readiness.
 const (
-	ReadyUnspecified Ready = iota
-	ReadyTrue
-	ReadyFalse
+	ReadyUnspecified Ready = "Unspecified"
+	ReadyTrue        Ready = "True"
+	ReadyFalse       Ready = "False"
 )
 
 // NewDesiredComposedResource returns a new, empty desired composed resource.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

This lets us print it (e.g. in logs) in a human-readable way. I considered using stringer to generate String() methods, but I don't think we really care about the size/perf benefits of this enum being an integer.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

It has not - I plan to update some functions to use it imminently though.