### PR TITLE
Allow falling through to the Insecure option

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -68,6 +68,14 @@ func Listen(network, address string) ServeOption {
 // well as a CA certificate (ca.crt) that will be used to authenticate clients.
 func MTLSCertificates(dir string) ServeOption {
 	return func(o *ServeOptions) error {
+		if dir == "" {
+			// We want to support passing both MTLSCertificates and
+			// Insecure as they were supplied as flags. So we don't
+			// want this to fail because no dir was supplied.
+			// If no TLS dir is supplied and insecure is false we'll
+			// return an error due to having no credentials specified.
+			return nil
+		}
 		crt, err := tls.LoadX509KeyPair(
 			filepath.Clean(filepath.Join(dir, "tls.crt")),
 			filepath.Clean(filepath.Join(dir, "tls.key")),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
If --tls-certs-dir is the empty string (i.e. not specified), we try see whether --insecure was supplied. If both are supplied, whichever was supplied last wins. If neither are supplied, you'll get an error that you didn't setup any credentials.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

It has not yet. 😬 I am about to test it by bumping function-dummy to use this though.