### PR TITLE
Make NewDesiredComposedResource return a pointer

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -64,8 +64,8 @@ const (
 )
 
 // NewDesiredComposedResource returns a new, empty desired composed resource.
-func NewDesiredComposedResource() DesiredComposed {
-	return DesiredComposed{Resource: composed.New()}
+func NewDesiredComposedResource() *DesiredComposed {
+	return &DesiredComposed{Resource: composed.New()}
 }
 
 // ObservedComposed reflects the observed state of a composed resource.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
You're most likely going to want to add this to the map returned by request.GetDesiredComposedResources then later pass that to response.SetDesiredComposedResources. The map in question is a map of resource name to *resource.DesiredComposed, so it's easiest if this returns that type.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
