### PR TITLE
Make a non-nil map of desired XR connection details

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -38,6 +38,11 @@ func GetObservedCompositeResource(req *v1beta1.RunFunctionRequest) (*resource.Co
 		Resource:          composite.New(),
 		ConnectionDetails: req.GetObserved().GetComposite().GetConnectionDetails(),
 	}
+
+	if xr.ConnectionDetails == nil {
+		xr.ConnectionDetails = make(resource.ConnectionDetails)
+	}
+
 	err := resource.AsObject(req.GetObserved().GetComposite().GetResource(), xr.Resource)
 	return xr, err
 }
@@ -47,6 +52,11 @@ func GetObservedComposedResources(req *v1beta1.RunFunctionRequest) (map[resource
 	ocds := map[resource.Name]resource.ObservedComposed{}
 	for name, r := range req.GetObserved().GetResources() {
 		ocd := resource.ObservedComposed{Resource: composed.New(), ConnectionDetails: r.GetConnectionDetails()}
+
+		if ocd.ConnectionDetails == nil {
+			ocd.ConnectionDetails = make(resource.ConnectionDetails)
+		}
+
 		if err := resource.AsObject(r.GetResource(), ocd.Resource); err != nil {
 			return nil, err
 		}
@@ -61,6 +71,11 @@ func GetDesiredCompositeResource(req *v1beta1.RunFunctionRequest) (*resource.Com
 		Resource:          composite.New(),
 		ConnectionDetails: req.GetDesired().GetComposite().GetConnectionDetails(),
 	}
+
+	if xr.ConnectionDetails == nil {
+		xr.ConnectionDetails = make(resource.ConnectionDetails)
+	}
+
 	err := resource.AsObject(req.GetDesired().GetComposite().GetResource(), xr.Resource)
 	return xr, err
 }

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2023 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package request contains utilities for working with RunFunctionRequests.
+package request
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/crossplane/function-sdk-go/proto/v1beta1"
+	"github.com/crossplane/function-sdk-go/resource"
+	"github.com/crossplane/function-sdk-go/resource/composed"
+	"github.com/crossplane/function-sdk-go/resource/composite"
+)
+
+func TestGetObservedCompositeResource(t *testing.T) {
+	type want struct {
+		oxr *resource.Composite
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		req    *v1beta1.RunFunctionRequest
+		want   want
+	}{
+		"NoObservedXR": {
+			reason: "In the unlikely event the request has no observed XR we should return a usable, empty Composite.",
+			req:    &v1beta1.RunFunctionRequest{},
+			want: want{
+				oxr: &resource.Composite{
+					Resource:          composite.New(),
+					ConnectionDetails: resource.ConnectionDetails{},
+				},
+			},
+		},
+		"ObservedXR": {
+			reason: "We should return the XR read from the request.",
+			req: &v1beta1.RunFunctionRequest{
+				Observed: &v1beta1.State{
+					Composite: &v1beta1.Resource{
+						Resource: resource.MustStructJSON(`{
+							"apiVersion": "test.crossplane.io/v1",
+							"kind": "XR"
+						}`),
+						ConnectionDetails: map[string][]byte{
+							"super": []byte("secret"),
+						},
+					},
+				},
+			},
+			want: want{
+				oxr: &resource.Composite{
+					Resource: &composite.Unstructured{Unstructured: unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": "test.crossplane.io/v1",
+							"kind":       "XR",
+						},
+					}},
+					ConnectionDetails: resource.ConnectionDetails{
+						"super": []byte("secret"),
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			oxr, err := GetObservedCompositeResource(tc.req)
+
+			if diff := cmp.Diff(tc.want.oxr, oxr); diff != "" {
+				t.Errorf("\n%s\nGetObservedCompositeResource(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err); diff != "" {
+				t.Errorf("\n%s\nGetObservedCompositeResource(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGetDesiredCompositeResource(t *testing.T) {
+	type want struct {
+		oxr *resource.Composite
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		req    *v1beta1.RunFunctionRequest
+		want   want
+	}{
+		"NoDesiredXR": {
+			reason: "If the request has no desired XR we should return a usable, empty Composite.",
+			req:    &v1beta1.RunFunctionRequest{},
+			want: want{
+				oxr: &resource.Composite{
+					Resource:          composite.New(),
+					ConnectionDetails: resource.ConnectionDetails{},
+				},
+			},
+		},
+		"DesiredXR": {
+			reason: "We should return the XR read from the request.",
+			req: &v1beta1.RunFunctionRequest{
+				Desired: &v1beta1.State{
+					Composite: &v1beta1.Resource{
+						Resource: resource.MustStructJSON(`{
+							"apiVersion": "test.crossplane.io/v1",
+							"kind": "XR"
+						}`),
+						ConnectionDetails: map[string][]byte{
+							"super": []byte("secret"),
+						},
+					},
+				},
+			},
+			want: want{
+				oxr: &resource.Composite{
+					Resource: &composite.Unstructured{Unstructured: unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": "test.crossplane.io/v1",
+							"kind":       "XR",
+						},
+					}},
+					ConnectionDetails: resource.ConnectionDetails{
+						"super": []byte("secret"),
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			oxr, err := GetDesiredCompositeResource(tc.req)
+
+			if diff := cmp.Diff(tc.want.oxr, oxr); diff != "" {
+				t.Errorf("\n%s\nGetDesiredCompositeResource(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err); diff != "" {
+				t.Errorf("\n%s\nGetDesiredCompositeResource(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGetObservedComposedResources(t *testing.T) {
+	type want struct {
+		ocds map[resource.Name]resource.ObservedComposed
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		req    *v1beta1.RunFunctionRequest
+		want   want
+	}{
+		"NoObservedComposedResources": {
+			reason: "If the request has no observed composed resources we should return an empty, non-nil map.",
+			req:    &v1beta1.RunFunctionRequest{},
+			want: want{
+				ocds: map[resource.Name]resource.ObservedComposed{},
+			},
+		},
+		"ObservedComposedResources": {
+			reason: "If the request has observed composed resources we should return them.",
+			req: &v1beta1.RunFunctionRequest{
+				Observed: &v1beta1.State{
+					Resources: map[string]*v1beta1.Resource{
+						"observed-composed-resource": {
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "test.crossplane.io/v1",
+								"kind": "Composed"
+							}`),
+							ConnectionDetails: map[string][]byte{
+								"super": []byte("secret"),
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				ocds: map[resource.Name]resource.ObservedComposed{
+					"observed-composed-resource": {
+						Resource: &composed.Unstructured{Unstructured: unstructured.Unstructured{
+							Object: map[string]any{
+								"apiVersion": "test.crossplane.io/v1",
+								"kind":       "Composed",
+							},
+						}},
+						ConnectionDetails: resource.ConnectionDetails{
+							"super": []byte("secret"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ocds, err := GetObservedComposedResources(tc.req)
+
+			if diff := cmp.Diff(tc.want.ocds, ocds); diff != "" {
+				t.Errorf("\n%s\nGetObservedComposedResources(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err); diff != "" {
+				t.Errorf("\n%s\nGetObservedComposedResources(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}
+
+func TestGetDesiredComposedResources(t *testing.T) {
+	type want struct {
+		dcds map[resource.Name]*resource.DesiredComposed
+		err  error
+	}
+
+	cases := map[string]struct {
+		reason string
+		req    *v1beta1.RunFunctionRequest
+		want   want
+	}{
+		"NoDesiredComposedResources": {
+			reason: "If the request has no desired composed resources we should return an empty, non-nil map.",
+			req:    &v1beta1.RunFunctionRequest{},
+			want: want{
+				dcds: map[resource.Name]*resource.DesiredComposed{},
+			},
+		},
+		"DesiredComposedResources": {
+			reason: "If the request has desired composed resources we should return them.",
+			req: &v1beta1.RunFunctionRequest{
+				Desired: &v1beta1.State{
+					Resources: map[string]*v1beta1.Resource{
+						"desired-composed-resource": {
+							Resource: resource.MustStructJSON(`{
+								"apiVersion": "test.crossplane.io/v1",
+								"kind": "Composed"
+							}`),
+							Ready: v1beta1.Ready_READY_TRUE,
+						},
+					},
+				},
+			},
+			want: want{
+				dcds: map[resource.Name]*resource.DesiredComposed{
+					"desired-composed-resource": {
+						Resource: &composed.Unstructured{Unstructured: unstructured.Unstructured{
+							Object: map[string]any{
+								"apiVersion": "test.crossplane.io/v1",
+								"kind":       "Composed",
+							},
+						}},
+						Ready: resource.ReadyTrue,
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ocds, err := GetDesiredComposedResources(tc.req)
+
+			if diff := cmp.Diff(tc.want.dcds, ocds); diff != "" {
+				t.Errorf("\n%s\nGetDesiredComposedResources(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.err, err); diff != "" {
+				t.Errorf("\n%s\nGetDesiredComposedResources(...): -want error, +got error:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This way even if the RunFunctionRequest doesn't include a desired XR, GetDesiredComposedResource will return a datastructure that you can mutate and return without fear of writing to a nil map.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I need to test that this will fix https://github.com/crossplane-contrib/function-patch-and-transform/issues/10.