### PR TITLE
fix(docs): Remove duplicate call to GetObservedCompositeResource in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ func (f *Function) RunFunction(_ context.Context, req *fnv1beta1.RunFunctionRequ
 	// Read the desired number of widgets from our observed XR. We don't have
 	// a struct for the XR, so we use an unstructured, fieldpath based getter.
 	widgets, err := oxr.Resource.GetInteger("spec.widgets")
-	oxr, err := request.GetObservedCompositeResource(req)
 	if err != nil {
 		response.Fatal(rsp, errors.Wrap(err, "cannot get desired spec.widgets from observed XR"))
 		return rsp, nil


### PR DESCRIPTION
### Description of your changes

I believe this is a mistaken duplicate line in the `README.md`.  The comment and call above seem to be for getting `spec.widgets` as well as the error check below.  I believe this

```
oxr, err := request.GetObservedCompositeResource(req)
```

line, was accidently copied from line #30 above and should be removed because it is confusing here

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

this is a readme change
