### PR TITLE
Reject unknown fields when converting from Struct to Object

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -91,7 +91,7 @@ func AsObject(s *structpb.Struct, o runtime.Object) error {
 	if err != nil {
 		return errors.Wrapf(err, "cannot marshal %T to JSON", s)
 	}
-	return errors.Wrapf(json.Unmarshal(b, o), "cannot unmarshal JSON from %T into %T", s, o)
+	return errors.Wrapf(json.Unmarshal(b, o, json.RejectUnknownMembers(true)), "cannot unmarshal JSON from %T into %T", s, o)
 }
 
 // AsStruct gets the supplied struct from the supplied Kubernetes object.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Closes https://github.com/crossplane/function-sdk-go/pull/123
Closes https://github.com/crossplane/function-sdk-go/pull/121

This is mostly useful when a function loads its input from the RunFunctionRequest. Crossplane isn't (yet) aware of input schema and will send anything the user supplies. See https://github.com/crossplane-contrib/function-patch-and-transform/pull/91#issuecomment-1942672309.

Right now that could include extra unknown, misindented, or typod fields and those will be silently ignored by the function. With this change in place they will result in an error.

This code will also be used to load desired and observed resource state, but it's unlikely for those to be invalid.

This is a small behavior change, but I feel okay with it. The new behavior is safer, probably won't affect anyone, and we're pre 1.0.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
