### PR TITLE
feat: updates logger interface for Functions

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -144,6 +144,6 @@ func Serve(fn v1beta1.FunctionRunnerServiceServer, o ...ServeOption) error {
 }
 
 // NewLogger returns a new logger.
-func NewLogger(debug bool) (logging.Logger, error) {
+func NewLogger(debug bool) (logging.FnLogger, error) {
 	return logging.NewLogger(debug)
 }


### PR DESCRIPTION
functions

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This change sets up `FnLogger` with Error() method and its implementation to allow for functions to log error instances along with adding them to `RunFunctionResponse`'s Results array.

Fixes #143 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `make reviewable` to ensure this PR is ready for review.~~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Manually tested against a local function that uses `FnLogger` in place of crossplane-runtime's logger as shown below:

```
type Function struct {
	fnv1beta1.UnimplementedFunctionRunnerServiceServer

	log    logging.FnLogger
}
```

[contribution process]: https://git.io/fj2m9
