### PR TITLE
chore: adding optional caller skip and an option to encode time in iso8601 for production logger

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -24,9 +24,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	"github.com/crossplane/function-sdk-go/errors"
 )
 
@@ -44,12 +44,31 @@ func NewLogrLogger(l logr.Logger) Logger {
 }
 
 // NewLogger returns a new logger.
-func NewLogger(debug bool) (logging.Logger, error) {
-	o := []zap.Option{zap.AddCallerSkip(1)}
+func NewLogger(debug, timeEncodeISO8601 bool, addCallerSkip ...int) (Logger, error) {
+	// default value for caller skip
+	callerSkip := 1
+	if len(addCallerSkip) > 0 {
+		callerSkip = addCallerSkip[0]
+	}
+
+	o := []zap.Option{zap.AddCallerSkip(callerSkip)}
 	if debug {
 		zl, err := zap.NewDevelopment(o...)
 		return NewLogrLogger(zapr.NewLogger(zl)), errors.Wrap(err, "cannot create development zap logger")
 	}
+
+	// If timeEncodeISO8601 is true, use ISO8601TimeEncoder for production logger.
+	if timeEncodeISO8601 {
+		pCfg := zap.NewProductionEncoderConfig()
+		pCfg.EncodeTime = zapcore.ISO8601TimeEncoder
+
+		p := zap.NewProductionConfig()
+		p.EncoderConfig = pCfg
+		zl, err := p.Build(o...)
+		return NewLogrLogger(zapr.NewLogger(zl)), errors.Wrap(err, "cannot create production zap logger")
+	}
+
+	// If timeEncodeISO8601 is false, use the default EpochTimeEncoder for production logger.
 	zl, err := zap.NewProduction(o...)
 	return NewLogrLogger(zapr.NewLogger(zl)), errors.Wrap(err, "cannot create production zap logger")
 }

--- a/sdk.go
+++ b/sdk.go
@@ -144,6 +144,6 @@ func Serve(fn v1beta1.FunctionRunnerServiceServer, o ...ServeOption) error {
 }
 
 // NewLogger returns a new logger.
-func NewLogger(debug bool) (logging.Logger, error) {
-	return logging.NewLogger(debug)
+func NewLogger(debug, timeEncodeISO8601 bool, addCallerSkip ...int) (logging.Logger, error) {
+	return logging.NewLogger(debug, timeEncodeISO8601, addCallerSkip...)
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds options to NewLogger function to encode time in iso8601 format for production logger and set a different caller skip number when initializing the logger.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested manually against a Composition function running in local kind cluster.

[contribution process]: https://git.io/fj2m9
