### PR TITLE
set grpc default message size to 4mb

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -41,7 +41,7 @@ import (
 const (
 	DefaultNetwork        = "tcp"
 	DefaultAddress        = ":9443"
-	DefaultMaxRecvMsgSize = 4096
+	DefaultMaxRecvMsgSize = 1024 * 1024 * 4
 )
 
 // ServeOptions configure how a Function is served.


### PR DESCRIPTION
#153 set the default size to 4kb instead of 4mb (which is the default for grpc)