### PR TITLE
Expose composite ready state in function response

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -39,6 +39,8 @@ type ConnectionDetails map[string][]byte
 type Composite struct {
 	Resource          *composite.Unstructured
 	ConnectionDetails ConnectionDetails
+
+	Ready Ready
 }
 
 // A Name uniquely identifies a composed resource within a Composition Function

--- a/response/response.go
+++ b/response/response.go
@@ -64,8 +64,20 @@ func SetDesiredCompositeResource(rsp *v1.RunFunctionResponse, xr *resource.Compo
 		rsp.Desired = &v1.State{}
 	}
 	s, err := resource.AsStruct(xr.Resource)
-	rsp.Desired.Composite = &v1.Resource{Resource: s, ConnectionDetails: xr.ConnectionDetails}
-	return errors.Wrapf(err, "cannot convert %T to desired composite resource", xr.Resource)
+	r := &v1.Resource{Resource: s, ConnectionDetails: xr.ConnectionDetails}
+	if err != nil {
+		return errors.Wrapf(err, "cannot convert %T to desired composite resource", xr.Resource)
+	}
+	switch xr.Ready {
+	case resource.ReadyUnspecified:
+		r.Ready = v1.Ready_READY_UNSPECIFIED
+	case resource.ReadyFalse:
+		r.Ready = v1.Ready_READY_FALSE
+	case resource.ReadyTrue:
+		r.Ready = v1.Ready_READY_TRUE
+	}
+	rsp.Desired.Composite = r
+	return nil
 }
 
 // SetDesiredComposedResources sets the desired composed resources in the


### PR DESCRIPTION
### Description of your changes

Exposes `.Desired.Composite.Ready` field added in https://github.com/crossplane/crossplane/pull/6021 in function response.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Tested with my own build of https://github.com/crossplane-contrib/function-go-templating/pull/446 that implements https://github.com/crossplane-contrib/function-go-templating/issues/153
